### PR TITLE
Show basic error information when capture start fails

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
@@ -320,17 +320,19 @@ namespace LogicAnalyzer
 
             if (settings.TriggerType != 0)
             {
-                if (!driver.StartPatternCapture(settings.Frequency, settings.PreTriggerSamples, settings.PostTriggerSamples, settings.CaptureChannels, settings.TriggerChannel, settings.TriggerBitCount, settings.TriggerPattern, settings.TriggerType == 2 ? true : false))
+                LogicAnalyzerDriver.ErrorCode result = driver.StartPatternCapture(settings.Frequency, settings.PreTriggerSamples, settings.PostTriggerSamples, settings.CaptureChannels, settings.TriggerChannel, settings.TriggerBitCount, settings.TriggerPattern, settings.TriggerType == 2 ? true : false);
+                if (result != ERR_NONE)
                 {
-                    await ShowError("Error", "Device reported error starting capture. Restart the device and try again.");
+                    await ShowError("Error", "Device reported error starting capture. Restart the device and try again. Error: "+Enum.GetName(typeof(LogicAnalyzerDriver.ErrorCode), result));
                     return;
                 }
             }
             else
             {
-                if (!driver.StartCapture(settings.Frequency, settings.PreTriggerSamples, settings.PostTriggerSamples, settings.CaptureChannels, settings.TriggerChannel, settings.TriggerInverted))
+                LogicAnalyzerDriver.ErrorCode result = driver.StartCapture(settings.Frequency, settings.PreTriggerSamples, settings.PostTriggerSamples, settings.CaptureChannels, settings.TriggerChannel, settings.TriggerInverted);
+                if (result != ERR_NONE)
                 {
-                    await ShowError("Error", "Device reported error starting capture. Restart the device and try again.");
+                    await ShowError("Error", "Device reported error starting capture. Restart the device and try again. Code: "+Enum.GetName(typeof(LogicAnalyzerDriver.ErrorCode), result));
                     return;
                 }
             }

--- a/Software/LogicAnalyzer/SharedDriver/LogicAnalyzerDriver.cs
+++ b/Software/LogicAnalyzer/SharedDriver/LogicAnalyzerDriver.cs
@@ -45,14 +45,28 @@ namespace SharedDriver
             baseStream.ReadTimeout = Timeout.Infinite;
         }
 
-        public bool StartCapture(int Frequency, int PreSamples, int PostSamples, int[] Channels, int TriggerChannel, bool TriggerInverted, Action<CaptureEventArgs>? CaptureCompletedHandler = null)
+        public enum : uint
+        {
+            ERR_NONE = 0x00000000;
+            ERR_UNKNOWN = 0xFFFFFFFF;
+            ERR_ALREADY_CAPTURING = 0x00000001;
+            ERR_INVALID_CHANNEL_CONFIG = 0x00000002;
+            ERR_INVALID_SAMPLE_CONFIG = 0x00000003;
+            ERR_INVALID_FREQUENCY = 0x00000004;
+        }
+
+        public ErrorCode StartCapture(int Frequency, int PreSamples, int PostSamples, int[] Channels, int TriggerChannel, bool TriggerInverted, Action<CaptureEventArgs>? CaptureCompletedHandler = null)
         {
 
             if (capturing)
-                return false;
+                return ERR_ALREADY_CAPTURING;
 
-            if (Channels == null || Channels.Length == 0 || PreSamples < 2 || PreSamples > (16 * 1024) || (PreSamples + PostSamples) >= (32 * 1024) || Frequency > 100000000)
-                return false;
+            if (Channels == null || Channels.Length == 0)
+                return ERR_INVALID_CHANNEL_CONFIG;
+            if (PreSamples < 2 || PreSamples > (16 * 1024) || (PreSamples + PostSamples) >= (32 * 1024))
+                return ERR_INVALID_SAMPLE_CONFIG;
+            if (Frequency > 100000000)
+                return ERR_INVALID_FREQUENCY;
 
             channelCount = Channels.Length;
             triggerChannel = Array.IndexOf(Channels, TriggerChannel);
@@ -89,18 +103,22 @@ namespace SharedDriver
             {
                 capturing = true;
                 Task.Run(() => ReadCapture(PreSamples + PostSamples));
-                return true;
+                return ERR_NONE;
             }
-            return false;
+            return ERR_UNKNOWN;
         }
-        public bool StartPatternCapture(int Frequency, int PreSamples, int PostSamples, int[] Channels, int TriggerChannel, int TriggerBitCount, UInt16 TriggerPattern, bool Fast, Action<CaptureEventArgs>? CaptureCompletedHandler = null)
+        public ErrorCode StartPatternCapture(int Frequency, int PreSamples, int PostSamples, int[] Channels, int TriggerChannel, int TriggerBitCount, UInt16 TriggerPattern, bool Fast, Action<CaptureEventArgs>? CaptureCompletedHandler = null)
         {
 
             if (capturing)
-                return false;
+                return ERR_ALREADY_CAPTURING;
 
-            if (Channels == null || Channels.Length == 0 || PreSamples < 2 || PreSamples > (16 * 1024) || (PreSamples + PostSamples) >= (32 * 1024) || Frequency > 100000000)
-                return false;
+            if (Channels == null || Channels.Length == 0)
+                return ERR_INVALID_CHANNEL_CONFIG;
+            if (PreSamples < 2 || PreSamples > (16 * 1024) || (PreSamples + PostSamples) >= (32 * 1024))
+                return ERR_INVALID_SAMPLE_CONFIG;
+            if (Frequency > 100000000)
+                return ERR_INVALID_FREQUENCY;
 
             channelCount = Channels.Length;
             triggerChannel = Array.IndexOf(Channels, TriggerChannel);
@@ -138,9 +156,9 @@ namespace SharedDriver
             {
                 capturing = true;
                 Task.Run(() => ReadCapture(PreSamples + PostSamples));
-                return true;
+                return ERR_NONE;
             }
-            return false;
+            return ERR_UNKNOWN;
         }
 
         public bool StopCapture()


### PR DESCRIPTION
Currently, the message is very vague and just says that there was an error. This isn't a ton better and it should probably be worked on more but it at least gives a better idea as to what the error actually is.

Additionally, the requirements for a successful capture should probably be shown in the README or somewhere more obvious. I had to dig through the source code to realize that the reason it wasn't capturing was because I set pre-samples to zero, thinking that I just wanted to maximize the number of samples after the trigger that it captured. I actually wound up reinstalling the firmware on the Pi Pico, redownloading the application from GitHub, rebooting both my machine and the Pi Pico several times, and was about to run a live linux distro until I saw that it was just because pre-samples has to be at least 2.

(Note: I haven't done any C# programming before and don't have a way to test this code. This is mostly an example of the general idea I have, although I don't know if it actually works.)