### PR TITLE
Rework I2C Parsing

### DIFF
--- a/Software/LogicAnalyzer/I2CProtocolAnalyzer/I2CAnalyzer.cs
+++ b/Software/LogicAnalyzer/I2CProtocolAnalyzer/I2CAnalyzer.cs
@@ -98,10 +98,11 @@ namespace I2CProtocolAnalyzer
                         {
                             // Reset addressByte from repeat start
                             addressByte = false;
-                            op = "Read";
                             segment.Value += "10b Op Change";
                             segment.Value += $"\r\nAddress: {addr}";
                             segment.Value += $" Op: {op}";
+                            // Don't change op until after adding current segment value
+                            op = "Read";
 
                         }
                         // else This is a new start with a new address


### PR DESCRIPTION
Fixes:
10bit I2C Parsing does not work  #86

* Comments for parsing/learning logic
* Changed segment value construction
* Added Address and operation to each segment
* Add 10 bit read detection
* Add Re-start / repeat start detection

![image](https://github.com/gusmanb/logicanalyzer/assets/485104/282b84d7-aec8-43bd-bc6d-1314e5a2178b)
