### PR TITLE
Update PythonInstallation.cs; for compatibility with Python 3.12+ in Linux

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/PythonInstallation.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/PythonInstallation.cs
@@ -17,8 +17,11 @@ ver = str(sys.version_info.major) + str(sys.version_info.minor);
 path = sys.exec_prefix;
 print(op.join(path, 'Python' + ver + '.dll'));";
 
-        const string linuxPyScript = @"from distutils import sysconfig;
-import os.path as op;
+        const string linuxPyScript = @"import os.path as op;
+try:
+    from distutils import sysconfig;
+except:
+    import sysconfig;
 v = sysconfig.get_config_vars();
 fpaths = [op.join(v[pv], v['LDLIBRARY']) for pv in ('LIBDIR', 'LIBPL')]; 
 print(list(filter(op.exists, fpaths))[0])";


### PR DESCRIPTION
Make the LogicAnalyzer compatible with Python 3.12+ in Linux.

Python 3.12 removed the module `distutils`.

> This module is no longer part of the Python standard library. It was removed in Python 3.12 after being deprecated in Python 3.10. The removal was decided in PEP 632, which has migration advice.
> 
> The last version of Python that provided the distutils module was Python 3.11.

https://docs.python.org/3.12/library/distutils.html