### PR TITLE
Allow configuring min/max displayable samples and drag slider

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/Classes/GeneralSettings.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Classes/GeneralSettings.cs
@@ -1,0 +1,8 @@
+namespace LogicAnalyzer.Classes
+{
+    public class GeneralSettings
+    {
+        public int MinSamples { get; set; } = 10;
+        public int MaxSamples { get; set; } = 10000;
+    }
+}

--- a/Software/LogicAnalyzer/LogicAnalyzer/Controls/SamplePreviewer.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Controls/SamplePreviewer.axaml.cs
@@ -188,12 +188,9 @@ namespace LogicAnalyzer.Controls
 
             double ratio = Bounds.Width / sampleCount;
             double newStart = x - dragOffset;
-            int first = (int)(newStart / ratio);
 
-            if (first < 0)
-                first = 0;
-            if (first > sampleCount - VisibleSamples)
-                first = sampleCount - VisibleSamples;
+            int first = (int)(newStart / ratio);
+            first = Math.Clamp(first, 0, sampleCount - VisibleSamples);
 
             ViewChanged?.Invoke(this, new ViewChangedEventArgs { FirstSample = first });
         }

--- a/Software/LogicAnalyzer/LogicAnalyzer/Controls/SamplePreviewer.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Controls/SamplePreviewer.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using LogicAnalyzer.Classes;
@@ -23,9 +24,13 @@ namespace LogicAnalyzer.Controls
         public int VisibleSamples { get; private set; }
 
         public event EventHandler<PinnedEventArgs>? PinnedChanged;
+        public event EventHandler<ViewChangedEventArgs>? ViewChanged;
 
         bool pinned = false;
         public bool Pinned { get { return pinned; } set { pinned = value; if (PinnedChanged != null) PinnedChanged(this, new PinnedEventArgs { Pinned = pinned }); } }
+
+        bool dragging = false;
+        double dragOffset = 0;
 
         public SamplePreviewer()
         {
@@ -125,6 +130,74 @@ namespace LogicAnalyzer.Controls
             InvalidateVisual();
         }
 
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+
+            if (e.Source == lblPin)
+                return;
+
+            var point = e.GetPosition(this);
+            double ratio = Bounds.Width / sampleCount;
+            double visibleWidth = VisibleSamples * ratio;
+            double startX = FirstSample * ratio;
+
+            if (point.X >= startX && point.X <= startX + visibleWidth)
+            {
+                dragOffset = point.X - startX;
+            }
+            else
+            {
+                dragOffset = visibleWidth / 2.0;
+                updateView(point.X);
+            }
+
+            dragging = true;
+            e.Pointer.Capture(this);
+        }
+
+        protected override void OnPointerMoved(PointerEventArgs e)
+        {
+            base.OnPointerMoved(e);
+
+            if (!dragging)
+                return;
+
+            var point = e.GetPosition(this);
+            updateView(point.X);
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            base.OnPointerReleased(e);
+
+            if (!dragging)
+                return;
+
+            dragging = false;
+            e.Pointer.Capture(null);
+
+            var point = e.GetPosition(this);
+            updateView(point.X);
+        }
+
+        void updateView(double x)
+        {
+            if (sampleCount == 0)
+                return;
+
+            double ratio = Bounds.Width / sampleCount;
+            double newStart = x - dragOffset;
+            int first = (int)(newStart / ratio);
+
+            if (first < 0)
+                first = 0;
+            if (first > sampleCount - VisibleSamples)
+                first = sampleCount - VisibleSamples;
+
+            ViewChanged?.Invoke(this, new ViewChangedEventArgs { FirstSample = first });
+        }
+
         private void TextBlock_PointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
         {
             pinned = !pinned;
@@ -136,6 +209,11 @@ namespace LogicAnalyzer.Controls
         public class PinnedEventArgs : EventArgs
         {
             public bool Pinned { get; set; }
+        }
+
+        public class ViewChangedEventArgs : EventArgs
+        {
+            public int FirstSample { get; set; }
         }
     }
 }

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
@@ -9,9 +9,9 @@
         Width="300" Height="180" CanResize="False" WindowStartupLocation="CenterOwner">
   <Panel>
     <Grid ColumnDefinitions="140,*" RowDefinitions="*,*,Auto" Margin="10,15,10,15">
-      <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,0,0">Min samples:</TextBlock>
+      <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,0,0">Min display samples:</TextBlock>
       <NumericUpDown Grid.Column="1" Grid.Row="0" Height="32" Minimum="1" Maximum="1000000" Name="nudMin" />
-      <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Margin="5,0,0,0">Max samples:</TextBlock>
+      <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Margin="5,0,0,0">Max display samples:</TextBlock>
       <NumericUpDown Grid.Column="1" Grid.Row="1" Height="32" Minimum="1" Maximum="1000000" Name="nudMax" />
       <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="2" HorizontalAlignment="Right">
         <Button Name="btnAccept">Accept</Button>

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
@@ -1,0 +1,22 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        x:Class="LogicAnalyzer.Dialogs.GeneralSettingsDialog"
+        Background="#383838" Title="Settings"
+        Classes="tool_window" Icon="/Assets/Ico40.ico"
+        Width="300" Height="180" CanResize="False" WindowStartupLocation="CenterOwner">
+  <Panel>
+    <Grid ColumnDefinitions="140,*" RowDefinitions="*,*,Auto" Margin="10,15,10,15">
+      <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,0,0">Min samples:</TextBlock>
+      <NumericUpDown Grid.Column="1" Grid.Row="0" Height="32" Minimum="1" Maximum="1000000" Name="nudMin" />
+      <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Margin="5,0,0,0">Max samples:</TextBlock>
+      <NumericUpDown Grid.Column="1" Grid.Row="1" Height="32" Minimum="1" Maximum="1000000" Name="nudMax" />
+      <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="2" HorizontalAlignment="Right">
+        <Button Name="btnAccept">Accept</Button>
+        <Button Name="btnCancel" Margin="10,0,0,0">Cancel</Button>
+      </StackPanel>
+    </Grid>
+  </Panel>
+</Window>

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
@@ -9,6 +9,9 @@ namespace LogicAnalyzer.Dialogs
         public int MinSamples { get; set; }
         public int MaxSamples { get; set; }
 
+        public int MinSamplesLimit { get; set; }
+        public int MaxSamplesLimit { get; set; }
+
         public GeneralSettingsDialog()
         {
             InitializeComponent();
@@ -20,8 +23,17 @@ namespace LogicAnalyzer.Dialogs
         {
             base.OnOpened(e);
             this.FixStartupPosition();
-            nudMin.Value = MinSamples;
-            nudMax.Value = MaxSamples;
+            nudMin.Minimum = MinSamplesLimit;
+            nudMin.Maximum = MaxSamplesLimit;
+            nudMax.Minimum = MinSamplesLimit;
+            nudMax.Maximum = MaxSamplesLimit;
+
+            nudMin.Value = Math.Clamp(MinSamples, MinSamplesLimit, MaxSamplesLimit);
+            nudMax.Value = Math.Clamp(MaxSamples, MinSamplesLimit, MaxSamplesLimit);
+
+            var tooltip = $"Min: {MinSamplesLimit:#,##0}\r\nMax: {MaxSamplesLimit:#,##0}";
+            ToolTip.SetTip(nudMin, tooltip);
+            ToolTip.SetTip(nudMax, tooltip);
         }
 
         private void BtnCancel_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using LogicAnalyzer.Extensions;
+using System;
+
+namespace LogicAnalyzer.Dialogs
+{
+    public partial class GeneralSettingsDialog : Window
+    {
+        public int MinSamples { get; set; }
+        public int MaxSamples { get; set; }
+
+        public GeneralSettingsDialog()
+        {
+            InitializeComponent();
+            btnAccept.Click += BtnAccept_Click;
+            btnCancel.Click += BtnCancel_Click;
+        }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            this.FixStartupPosition();
+            nudMin.Value = MinSamples;
+            nudMax.Value = MaxSamples;
+        }
+
+        private void BtnCancel_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            Close(false);
+        }
+
+        private async void BtnAccept_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (nudMax.Value < nudMin.Value)
+            {
+                await this.ShowError("Invalid settings", "Max samples must be greater than Min samples.");
+                return;
+            }
+            MinSamples = (int)nudMin.Value;
+            MaxSamples = (int)nudMax.Value;
+            Close(true);
+        }
+    }
+}

--- a/Software/LogicAnalyzer/LogicAnalyzer/LogicAnalyzer.csproj
+++ b/Software/LogicAnalyzer/LogicAnalyzer/LogicAnalyzer.csproj
@@ -52,6 +52,9 @@
     <Compile Update="Dialogs\SelectedRegionDialog.axaml.cs">
       <DependentUpon>SelectedRegionDialog.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Dialogs\GeneralSettingsDialog.axaml.cs">
+      <DependentUpon>GeneralSettingsDialog.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
@@ -92,7 +92,14 @@
               10000
             </TextBlock>
             <Border Grid.Row="2" Grid.ColumnSpan="3" Margin="10,0,10,0" >
-              <Slider Margin="0,-10,0,0" TickFrequency="50" TickPlacement="BottomRight" Minimum="10" Maximum="10000" Value="1024" Name="tkInScreen"></Slider>
+              <Slider Margin="0,-10,0,0"
+                      TickFrequency="50"
+                      TickPlacement="BottomRight"
+                      Minimum="10"
+                      Maximum="10000"
+                      Value="1024"
+                      Name="tkInScreen"
+                      ToolTip.Tip="{Binding Value, RelativeSource={RelativeSource Self}, StringFormat='{}{0:F0}'}"></Slider>
             </Border>
           </Grid>
           <StackPanel Margin="5,5,5,0" Background="#80383838">

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
@@ -17,7 +17,8 @@
           <Separator/>
           <MenuItem Header="_Exit" Name="mnuExit"/>
         </MenuItem>
-      <MenuItem Header="Network settings" IsEnabled="False" Name="mnuSettings">
+      <MenuItem Header="_Settings" Name="mnuSettings">
+        <MenuItem Header="General..." Name="mnuGeneralSettings"></MenuItem>
         <MenuItem Header="Update network settings" Name="mnuNetSettings"></MenuItem>
       </MenuItem>
       <MenuItem Header="Profiles" Name="mnuProfiles" IsEnabled="False">

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
@@ -18,7 +18,7 @@
           <MenuItem Header="_Exit" Name="mnuExit"/>
         </MenuItem>
       <MenuItem Header="_Settings" Name="mnuSettings">
-        <MenuItem Header="General..." Name="mnuGeneralSettings"></MenuItem>
+        <MenuItem Header="General" Name="mnuGeneralSettings"></MenuItem>
         <MenuItem Header="Update network settings" Name="mnuNetSettings"></MenuItem>
       </MenuItem>
       <MenuItem Header="Profiles" Name="mnuProfiles" IsEnabled="False">

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
@@ -91,16 +91,19 @@
             <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,5,10,0" Name="lblMaxSamples" HorizontalAlignment="Right">
               10000
             </TextBlock>
-            <Border Grid.Row="2" Grid.ColumnSpan="3" Margin="10,0,10,0" >
-              <Slider Margin="0,-10,0,0"
-                      TickFrequency="50"
-                      TickPlacement="BottomRight"
-                      Minimum="10"
-                      Maximum="10000"
-                      Value="1024"
-                      Name="tkInScreen"
-                      ToolTip.Tip="{Binding Value, RelativeSource={RelativeSource Self}, StringFormat='{}{0:F0}'}"></Slider>
-            </Border>
+              <Border Grid.Row="2" Grid.ColumnSpan="3" Margin="10,0,10,0" >
+                  <Slider Margin="0,-10,0,0"
+                          TickFrequency="50"
+                          TickPlacement="BottomRight"
+                          Minimum="10"
+                          Maximum="10000"
+                          Value="1024"
+                          Name="tkInScreen"
+                          ToolTip.ShowDelay="0"
+                          ToolTip.Placement="AnchorAndGravity"
+                          ToolTip.Tip="{Binding Value, RelativeSource={RelativeSource Self}, StringFormat='{}{0:F0}'}">
+                  </Slider>
+              </Border>
           </Grid>
           <StackPanel Margin="5,5,5,0" Background="#80383838">
             <TextBlock Margin="5,2,5,2">

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
@@ -98,7 +98,8 @@ namespace LogicAnalyzer
             sampleMarker.SamplesInserted += SampleMarker_SamplesInserted;
             sampleMarker.SamplesDeleted += SampleMarker_SamplesDeleted;
 
-            samplePreviewer.PinnedChanged += SamplePreviewer_PinnedChanged;
+           samplePreviewer.PinnedChanged += SamplePreviewer_PinnedChanged;
+            samplePreviewer.ViewChanged += SamplePreviewer_ViewChanged;
 
             sampleViewer.PointerWheelChanged += SampleViewer_PointerWheelChanged;
             tkInScreen.PointerWheelChanged += TkInScreen_PointerWheelChanged;
@@ -144,7 +145,7 @@ namespace LogicAnalyzer
                 tmrSliderToolTip.Stop();
             };
 
-            this.Closed += (o, e) => 
+            this.Closed += (o, e) =>
             {
                 if (driver != null && driver.IsCapturing)
                 {
@@ -254,7 +255,7 @@ namespace LogicAnalyzer
             if (driver == null)
             {
                 await this.ShowError("Load profile", "No device connected, cannot load profile.");
-                return; 
+                return;
             }
 
             var mnu = sender as MenuItem;
@@ -296,16 +297,16 @@ namespace LogicAnalyzer
 
         private async void AddProfile_Click(object? sender, RoutedEventArgs e)
         {
-            var dlg = MessageBoxManager.GetMessageBoxCustom(new MsBox.Avalonia.Dto.MessageBoxCustomParams 
+            var dlg = MessageBoxManager.GetMessageBoxCustom(new MsBox.Avalonia.Dto.MessageBoxCustomParams
             {
                 ButtonDefinitions = new List<MsBox.Avalonia.Models.ButtonDefinition>
                 {
                     new MsBox.Avalonia.Models.ButtonDefinition { Name = "Cancel", IsCancel = true, IsDefault = false },
                     new MsBox.Avalonia.Models.ButtonDefinition { Name = "Save", IsCancel = false, IsDefault = true }
                 },
-                InputParams = new MsBox.Avalonia.Dto.InputParams 
-                { 
-                    Label = "New profile name:", Multiline = false 
+                InputParams = new MsBox.Avalonia.Dto.InputParams
+                {
+                    Label = "New profile name:", Multiline = false
                 },
                 Icon = MsBox.Avalonia.Enums.Icon.Setting,
                 ContentTitle = "Add profile",
@@ -506,6 +507,11 @@ namespace LogicAnalyzer
             }
         }
 
+        private void SamplePreviewer_ViewChanged(object? sender, SamplePreviewer.ViewChangedEventArgs e)
+        {
+            updateSamplesInDisplay(e.FirstSample, (int)tkInScreen.Value);
+        }
+
         private void ChannelViewer_ChannelVisibilityChanged(object? sender, EventArgs e)
         {
             UpdateVisibility();
@@ -548,14 +554,14 @@ namespace LogicAnalyzer
 
             if (e.Annotations != null && e.Annotations.Any())
             {
-                
+
 
                 foreach(var grp in e.Annotations)
                 {
                     annotationsViewer.AddAnnotationsGroup(grp);
                 }
 
-                
+
             }
 
             annotationsViewer.EndUpdate();
@@ -604,8 +610,8 @@ namespace LogicAnalyzer
             {
                 OpenUrl("https://github.com/gusmanb/logicanalyzer/wiki");
             }
-            catch 
-            { 
+            catch
+            {
                 await this.ShowError("Cannot open page.", "Cannot start the default browser. You can access the online documentation in https://github.com/gusmanb/logicanalyzer/wiki");
             }
         }
@@ -795,10 +801,10 @@ namespace LogicAnalyzer
                 dlgCreate.InsertMode = false;
                 dlgCreate.Initialize(
                     channels,
-                    names, 
+                    names,
                     stn.PreTriggerSamples + stn.PostTriggerSamples,
                     stn.PreTriggerSamples + stn.PostTriggerSamples);
-                
+
                 var samples = await dlgCreate.ShowDialog<byte[][]?>(this);
 
                 if (samples == null)
@@ -806,7 +812,7 @@ namespace LogicAnalyzer
 
                 session = stn;
                 driver = drv;
-                
+
                 for (int chan = 0; chan < stn.CaptureChannels.Length; chan++)
                     stn.CaptureChannels[chan].Samples = samples[chan];
 
@@ -867,7 +873,7 @@ namespace LogicAnalyzer
                 return;
 
             await InsertSamples(e.Sample, samples);
-            
+
         }
 
         private async Task InsertSamples(int sample, IEnumerable<byte[]> newSamples)
@@ -1068,7 +1074,7 @@ namespace LogicAnalyzer
             if (finalRegions.Count > 0)
                 addRegions(finalRegions);
 
-            
+
 
             scrSamplePos.Maximum = totalSamples - 1;
             updateSamplesInDisplay(firstSample - 1, (int)tkInScreen.Value);
@@ -1286,7 +1292,7 @@ namespace LogicAnalyzer
                     syncUI();
                 }
 
-                
+
             }
             else
             {
@@ -1420,8 +1426,8 @@ namespace LogicAnalyzer
 
         private KnownDevice? GetKnownDevice(DetectedDevice[] detected)
         {
-            var device = knownDevices.FirstOrDefault(d => d.Entries.Length == detected.Length && 
-            d.Entries.All(e => 
+            var device = knownDevices.FirstOrDefault(d => d.Entries.Length == detected.Length &&
+            d.Entries.All(e =>
             detected.Any(dd => dd.SerialNumber == e.SerialNumber)));
 
             return device;
@@ -1448,7 +1454,7 @@ namespace LogicAnalyzer
 
             string[] parts = powerStatus.Split("_");
 
-            if(parts.Length == 2 ) 
+            if(parts.Length == 2 )
             {
                 lblVoltage.Text = parts[0];
 
@@ -1460,9 +1466,9 @@ namespace LogicAnalyzer
                 if (oldSrc is IDisposable)
                     ((IDisposable)oldSrc).Dispose();
             }
-                    
+
         }
-        
+
         private void btnRefresh_Click(object? sender, RoutedEventArgs e)
         {
             RefreshPorts();
@@ -1495,7 +1501,7 @@ namespace LogicAnalyzer
             ddPorts.ItemsSource = null;
             ddPorts.ItemsSource = portItems.ToArray();
             ddPorts.SelectedIndex = 0;
-            
+
         }
 
         private async void btnRepeat_Click(object? sender, RoutedEventArgs e)
@@ -1520,7 +1526,7 @@ namespace LogicAnalyzer
                 return;
 
             var dialog = new CaptureDialog();
-            
+
             dialog.Initialize(driver);
 
             if (!await dialog.ShowDialog<bool>(this))
@@ -1535,7 +1541,7 @@ namespace LogicAnalyzer
 
             var settingsFile = $"cpSettings{driver.DriverType}.json";
             var settings = session.Clone();
-                
+
             foreach(var channel in settings.CaptureChannels)
                 channel.Samples = null;
 
@@ -1699,7 +1705,7 @@ namespace LogicAnalyzer
                     LoadInfo();
                 }
             }
-            catch(Exception ex) 
+            catch(Exception ex)
             {
                 await this.ShowError("Unhandled exception", $"{ex.Message} - {ex.StackTrace}");
             }

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
@@ -53,6 +53,7 @@ namespace LogicAnalyzer
 
         //bool preserveSamples = false;
         Timer tmrHideSamples;
+        DispatcherTimer tmrSliderToolTip;
 
         List<ISampleDisplay> sampleDisplays = new List<ISampleDisplay>();
         List<IRegionDisplay> regionDisplays = new List<IRegionDisplay>();
@@ -135,6 +136,13 @@ namespace LogicAnalyzer
                         samplePreviewer.IsVisible = false;
                 });
             });
+
+            tmrSliderToolTip = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            tmrSliderToolTip.Tick += (o, e) =>
+            {
+                ToolTip.SetIsOpen(tkInScreen, false);
+                tmrSliderToolTip.Stop();
+            };
 
             this.Closed += (o, e) => 
             {
@@ -1596,6 +1604,13 @@ namespace LogicAnalyzer
         private void tkInScreen_ValueChanged(object? sender, Avalonia.AvaloniaPropertyChangedEventArgs e)
         {
             updateSampleDisplays();
+
+            if (e.Property == RangeBase.ValueProperty)
+            {
+                ToolTip.SetIsOpen(tkInScreen, true);
+                tmrSliderToolTip.Stop();
+                tmrSliderToolTip.Start();
+            }
 
         }
 

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
@@ -1144,7 +1144,7 @@ namespace LogicAnalyzer
                 var channels = session?.CaptureChannels?.Select(c => (int)c.ChannelNumber).ToArray() ?? Enumerable.Range(0, driver.ChannelCount).ToArray();
                 var limits = driver.GetLimits(channels);
                 minSamples = limits.MinPreSamples + limits.MinPostSamples;
-                maxSamples = limits.MaxPreSamples + limits.MaxPostSamples;
+                maxSamples = limits.MaxTotalSamples;
             }
 
             var dlg = new GeneralSettingsDialog

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml.cs
@@ -98,7 +98,7 @@ namespace LogicAnalyzer
             sampleMarker.SamplesInserted += SampleMarker_SamplesInserted;
             sampleMarker.SamplesDeleted += SampleMarker_SamplesDeleted;
 
-           samplePreviewer.PinnedChanged += SamplePreviewer_PinnedChanged;
+            samplePreviewer.PinnedChanged += SamplePreviewer_PinnedChanged;
             samplePreviewer.ViewChanged += SamplePreviewer_ViewChanged;
 
             sampleViewer.PointerWheelChanged += SampleViewer_PointerWheelChanged;
@@ -133,7 +133,7 @@ namespace LogicAnalyzer
             {
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    if(!samplePreviewer.Pinned)
+                    if (!samplePreviewer.Pinned)
                         samplePreviewer.IsVisible = false;
                 });
             });
@@ -153,7 +153,7 @@ namespace LogicAnalyzer
                     driver.Dispose();
                 }
 
-                if(decoderProvider != null)
+                if (decoderProvider != null)
                     decoderProvider.Dispose();
             };
 
@@ -169,7 +169,7 @@ namespace LogicAnalyzer
             regionDisplays.Add(sampleMarker);
             regionDisplays.Add(annotationsViewer);
 
-             Task.Run(() => LoadKnownDevices());
+            Task.Run(() => LoadKnownDevices());
 
             RefreshPorts();
             LoadProfiles();
@@ -179,10 +179,7 @@ namespace LogicAnalyzer
             tkInScreen.Maximum = generalSettings.MaxSamples;
             lblMinSamples.Text = generalSettings.MinSamples.ToString();
             lblMaxSamples.Text = generalSettings.MaxSamples.ToString();
-            if (tkInScreen.Value < tkInScreen.Minimum)
-                tkInScreen.Value = tkInScreen.Minimum;
-            if (tkInScreen.Value > tkInScreen.Maximum)
-                tkInScreen.Value = tkInScreen.Maximum;
+            tkInScreen.Value = Math.Clamp(tkInScreen.Value, tkInScreen.Minimum, tkInScreen.Maximum);
 
             try
             {
@@ -209,7 +206,7 @@ namespace LogicAnalyzer
 
             if (profiles != null)
             {
-                foreach(var profile in profiles.Profiles)
+                foreach (var profile in profiles.Profiles)
                 {
                     var mnuProfile = new MenuItem { Header = profile.Name };
                     mnuProfiles.Items.Add(mnuProfile);
@@ -270,7 +267,7 @@ namespace LogicAnalyzer
 
             if (driver.IsCapturing)
             {
-                if (! await this.ShowConfirm("Load profile", "There is a capture in progress. Do you want to stop it and load the profile?"))
+                if (!await this.ShowConfirm("Load profile", "There is a capture in progress. Do you want to stop it and load the profile?"))
                     return;
 
                 driver.StopCapture();
@@ -306,7 +303,8 @@ namespace LogicAnalyzer
                 },
                 InputParams = new MsBox.Avalonia.Dto.InputParams
                 {
-                    Label = "New profile name:", Multiline = false
+                    Label = "New profile name:",
+                    Multiline = false
                 },
                 Icon = MsBox.Avalonia.Enums.Icon.Setting,
                 ContentTitle = "Add profile",
@@ -318,7 +316,7 @@ namespace LogicAnalyzer
 
             var result = await dlg.ShowWindowDialogAsync(this);
 
-            if(result == "Save")
+            if (result == "Save")
             {
                 var profileName = dlg.InputValue;
 
@@ -343,7 +341,7 @@ namespace LogicAnalyzer
 
         private async void LblForget_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if(currentKnownDevice != null)
+            if (currentKnownDevice != null)
             {
 
                 if (await this.ShowConfirm("Forget device", "Are you sure you want to forget this device?"))
@@ -364,7 +362,7 @@ namespace LogicAnalyzer
         {
             var knownDevices = AppSettingsManager.GetSettings<List<KnownDevice>>("knownDevices.json");
 
-            if(knownDevices != null)
+            if (knownDevices != null)
                 this.knownDevices = knownDevices;
         }
 
@@ -393,7 +391,7 @@ namespace LogicAnalyzer
 
         private async void LblInfo_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if(driver != null)
+            if (driver != null)
             {
                 var dlg = new AnalyzerInfoDialog();
                 dlg.Initialize(driver);
@@ -406,7 +404,7 @@ namespace LogicAnalyzer
 
         private void ScrSamplePos_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
         {
-            if(e.Delta.Y < 0)
+            if (e.Delta.Y < 0)
             {
                 var currentVal = scrSamplePos.Value;
                 int newVal = (int)(currentVal - scrSamplePos.Maximum / 20);
@@ -466,7 +464,7 @@ namespace LogicAnalyzer
                     var currentValue = scrSamplePos.Value;
                     currentValue += (int)increment;
 
-                    if(currentValue > scrSamplePos.Maximum)
+                    if (currentValue > scrSamplePos.Maximum)
                         currentValue = (int)scrSamplePos.Maximum;
 
                     updateSamplesInDisplay((int)currentValue, (int)tkInScreen.Value);
@@ -519,10 +517,10 @@ namespace LogicAnalyzer
 
         private void Visibility_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if(session?.CaptureChannels == null)
+            if (session?.CaptureChannels == null)
                 return;
 
-            foreach(var channel in session.CaptureChannels)
+            foreach (var channel in session.CaptureChannels)
                 channel.Hidden = false;
 
             UpdateVisibility();
@@ -540,7 +538,7 @@ namespace LogicAnalyzer
             {
                 tkInScreen.Value = Math.Min(tkInScreen.Maximum, tkInScreen.Value * 1.5);
             }
-            else if(e.Delta.Y < 0)
+            else if (e.Delta.Y < 0)
             {
                 tkInScreen.Value = Math.Max(tkInScreen.Minimum, tkInScreen.Value / 1.5);
             }
@@ -556,7 +554,7 @@ namespace LogicAnalyzer
             {
 
 
-                foreach(var grp in e.Annotations)
+                foreach (var grp in e.Annotations)
                 {
                     annotationsViewer.AddAnnotationsGroup(grp);
                 }
@@ -744,7 +742,7 @@ namespace LogicAnalyzer
                 {
                     var samples = channel.Samples;
 
-                    if(samples == null)
+                    if (samples == null)
                         continue;
 
                     int idx = Array.IndexOf(channelViewer.Channels, channel);
@@ -790,7 +788,7 @@ namespace LogicAnalyzer
             var drv = new EmulatedAnalyzerDriver(5);
             dlg.Initialize(drv);
 
-            if(await dlg.ShowDialog<bool>(this))
+            if (await dlg.ShowDialog<bool>(this))
             {
                 var stn = dlg.SelectedSettings;
                 var channels = stn.CaptureChannels.Select(c => c.ChannelNumber).ToArray();
@@ -840,7 +838,7 @@ namespace LogicAnalyzer
                 return;
             }
 
-            if(copiedSamples != null)
+            if (copiedSamples != null)
                 await InsertSamples(e.Sample, copiedSamples);
         }
 
@@ -895,7 +893,7 @@ namespace LogicAnalyzer
                 return;
             }
 
-            for(int chan = 0; chan < session.CaptureChannels.Length; chan++)
+            for (int chan = 0; chan < session.CaptureChannels.Length; chan++)
             {
                 var channel = session.CaptureChannels[chan];
                 var cSamples = channel.Samples;
@@ -1139,6 +1137,7 @@ namespace LogicAnalyzer
             int minSamples = 1;
             int maxSamples = 10000;
 
+            // get device limits when connected
             if (driver != null)
             {
                 var channels = session?.CaptureChannels?.Select(c => (int)c.ChannelNumber).ToArray() ?? Enumerable.Range(0, driver.ChannelCount).ToArray();
@@ -1164,10 +1163,7 @@ namespace LogicAnalyzer
                 tkInScreen.Maximum = generalSettings.MaxSamples;
                 lblMinSamples.Text = generalSettings.MinSamples.ToString();
                 lblMaxSamples.Text = generalSettings.MaxSamples.ToString();
-                if (tkInScreen.Value < tkInScreen.Minimum)
-                    tkInScreen.Value = tkInScreen.Minimum;
-                if (tkInScreen.Value > tkInScreen.Maximum)
-                    tkInScreen.Value = tkInScreen.Maximum;
+                tkInScreen.Value = Math.Clamp(tkInScreen.Value, tkInScreen.Minimum, tkInScreen.Maximum);
             }
         }
 
@@ -1277,7 +1273,7 @@ namespace LogicAnalyzer
                     if (port == null)
                         return;
 
-                    switch(port.Port)
+                    switch (port.Port)
                     {
                         case "Autodetect":
                             driver = await BeginAutodetect();
@@ -1294,7 +1290,7 @@ namespace LogicAnalyzer
 
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     await this.ShowError("Error", $"Cannot connect to device: ({ex.Message}).");
                     return;
@@ -1459,7 +1455,7 @@ namespace LogicAnalyzer
                 return;
             }
 
-            if(driver.IsCapturing)
+            if (driver.IsCapturing)
                 return;
 
             var powerStatus = driver.GetVoltageStatus();
@@ -1472,7 +1468,7 @@ namespace LogicAnalyzer
 
             string[] parts = powerStatus.Split("_");
 
-            if(parts.Length == 2 )
+            if (parts.Length == 2)
             {
                 lblVoltage.Text = parts[0];
 
@@ -1552,7 +1548,7 @@ namespace LogicAnalyzer
 
             session = dialog.SelectedSettings;
 
-            if(!await BeginCapture())
+            if (!await BeginCapture())
                 return;
 
             this.Title = Version;
@@ -1560,7 +1556,7 @@ namespace LogicAnalyzer
             var settingsFile = $"cpSettings{driver.DriverType}.json";
             var settings = session.Clone();
 
-            foreach(var channel in settings.CaptureChannels)
+            foreach (var channel in settings.CaptureChannels)
                 channel.Samples = null;
 
             AppSettingsManager.PersistSettings(settingsFile, settings);
@@ -1695,7 +1691,7 @@ namespace LogicAnalyzer
 
                     if (ex.Samples != null)
                     {
-                        for(int buc = 0; buc < session.CaptureChannels.Length; buc++)
+                        for (int buc = 0; buc < session.CaptureChannels.Length; buc++)
                             ExtractSamples(session.CaptureChannels[buc], buc, ex.Samples);
                     }
 
@@ -1723,7 +1719,7 @@ namespace LogicAnalyzer
                     LoadInfo();
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 await this.ShowError("Unhandled exception", $"{ex.Message} - {ex.StackTrace}");
             }
@@ -1746,7 +1742,7 @@ namespace LogicAnalyzer
         private string GenerateStringTrigger(ushort triggerPattern, int bitCount)
         {
             string value = "";
-            for(int buc = 0; buc < bitCount; buc++)
+            for (int buc = 0; buc < bitCount; buc++)
                 value += (triggerPattern & (1 << buc)) == 0 ? "0" : "1";
             return value;
         }


### PR DESCRIPTION
Adds a settings menu to allow configuring the min/max samples on screen. This lets us display more than 10,000 samples on screen. I had some lower frequency signals that I wanted to look at that I couldn't fit entirely on screen without messing with the sample frequency and even then it was tough to capture my whole signal.

<img width="1713" height="1025" alt="image" src="https://github.com/user-attachments/assets/77d731c5-668b-4add-a3e3-a9a981424833" />

Min/max sample limits come from the connected device, or are 10-10000 by default when disconnected.

<img width="302" height="212" alt="image" src="https://github.com/user-attachments/assets/c23d674f-3b21-4c4b-9541-cb7e4daf474e" />

<img width="1713" height="1025" alt="image" src="https://github.com/user-attachments/assets/c88228df-0b2f-4d35-8b34-022df0c367fc" />

Also added a tooltip to the samples on screen slider when dragging or hovering to show the number we're at.

<img width="405" height="151" alt="image" src="https://github.com/user-attachments/assets/8d1ed073-3e71-4018-9e6e-d54f9c4dfc34" />

And finally adds the ability to move the slider window by dragging it with the mouse in the preview view at the bottom.

https://imgur.com/a/7HR9dBu

Rebased onto latest version/v6_5, everything seems to be working nicely