### PR TITLE
SigrokDecoderBridge: Remove whitespace from python.cfg

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/SigrokPythonEngine.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/SigrokPythonEngine.cs
@@ -47,8 +47,8 @@ namespace SigrokDecoderBridge
                     if (File.Exists(cfgFile))
                     {
                         Log("Reading python path from config file...");
-                        pythonPath = File.ReadAllText(cfgFile);
-                        Log($"Stablished path: {pythonPath}");
+                        pythonPath = File.ReadAllText(cfgFile).Trim();
+                        Log($"Established path: {pythonPath}");
                     }
                     else
                     {
@@ -65,7 +65,7 @@ namespace SigrokDecoderBridge
                             var selectedVersion = validInstallations.OrderByDescending(p => p.MinorVersion).First();
                             pythonPath = selectedVersion.Path;
                             Log($"Selected version: {selectedVersion.MajorVersion}.{selectedVersion.MinorVersion}");
-                            Log($"Stablished path: {selectedVersion.Path}");
+                            Log($"Established path: {selectedVersion.Path}");
                         }
                         else
                         {


### PR DESCRIPTION
I see lots of issues about trailing newlines when trying to find python. Could you try this to see if this fixes up the pythonPath string of any leading or trailing white space.

Note: I'm not a C Sharp programmer, but do program Python a lot,
    and I don't currently own one of your logic analysers, so this
    patch is untested, but should work.