### PR TITLE
Trimming whitespace from python library path read from config file

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/SigrokPythonEngine.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/SigrokDecoderBridge/SigrokPythonEngine.cs
@@ -72,7 +72,6 @@ namespace SigrokDecoderBridge
                             Log("No valid python installation found, aborting startup.");
                             return false;
                         }
-
                     }
 
                     if (string.IsNullOrWhiteSpace(pythonPath))
@@ -80,6 +79,8 @@ namespace SigrokDecoderBridge
                         Log("Python library not found, aborting startup.");
                         return false;
                     }
+
+                    pythonPath = pythonPath.Trim();
 
                     Log($"Initializing decoders...");
                     //Ensure the decode script is in place


### PR DESCRIPTION
Trimming whitespace from python library path read from config file.

Some editors automatically add new lines that leads into python library not being found on systems with different python versions preinstalled (e.g. Fedora 43).

This is to address the issue mentioned here [error loading decoders](https://github.com/gusmanb/logicanalyzer/issues/199)

Thanks