### PR TITLE
Add sorting by ChannelName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,3 +386,5 @@ logicanalyzer.wiki/
 Old/
 Electronics/LogicAnalyzer/LogicAnalyzerPro*/
 Electronics/LogicAnalyzer/LogicAnalyzerV2/packages/
+*.DS_Store
+cpSettingsSerial.json

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml
@@ -3,15 +3,15 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:uc="clr-namespace:LogicAnalyzer.Controls;assembly=LogicAnalyzer"
-        mc:Ignorable="d" d:DesignWidth="930" d:DesignHeight="680"
-        MaxWidth="930" MinWidth="930" Width="930" MaxHeight="680" MinHeight="680" Height="680"
+        mc:Ignorable="d" d:DesignWidth="1030" d:DesignHeight="680"
+        MaxWidth="1030" MinWidth="1030" Width="1030" MaxHeight="680" MinHeight="680" Height="680"
         CanResize="False" WindowStartupLocation="CenterOwner"
         x:Class="LogicAnalyzer.Dialogs.CaptureDialog"
         Title="Capture settings"
         Background="#383838" Icon="/Assets/Ico40.ico">
   <Panel>
     <Grid RowDefinitions="1*,14*,0.7*" Margin="8,15,8,15" Name="grdBase">
-      <Grid Grid.Row="0" ColumnDefinitions="1.4*,*,*" Margin="15,0,15,0">
+      <Grid Grid.Row="0" ColumnDefinitions="1.4*,*,*,150" Margin="15,0,15,0">
         <StackPanel Grid.Column="0" Orientation="Horizontal">
           <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Frequency:</TextBlock>
           <NumericUpDown Width="165" Height="35" Minimum="3100" Maximum="100000000" Value="100000000" Name="nudFrequency" FormatString="#,##0"></NumericUpDown>
@@ -23,9 +23,13 @@
           <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Presamples:</TextBlock>
           <NumericUpDown Width="135" Height="35" Value="512" Minimum="2" Maximum="98303" Name="nudPreSamples" FormatString="#,##0"></NumericUpDown>
         </StackPanel>
-        <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Center">
           <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Postsamples:</TextBlock>
           <NumericUpDown Width="135" Height="35" Value="1024" Minimum="512" Maximum="131069" Name="nudPostSamples" FormatString="#,##0"></NumericUpDown>
+        </StackPanel>
+        <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right">
+          <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Sort:</TextBlock>
+          <CheckBox Name="chkSortByChannel" IsChecked="True" Margin="0,0,10,0" VerticalAlignment="Center">by channel</CheckBox>
         </StackPanel>
       </Grid>
       <Grid Grid.Row="1" RowDefinitions="15*,14*" Name="grdMainContainer">

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -16,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using static System.Collections.Specialized.BitVector32;
 using static System.Net.Mime.MediaTypeNames;
@@ -57,8 +59,26 @@ namespace LogicAnalyzer.Dialogs
             nudFrequency.ValueChanged += NudFrequency_ValueChanged;
             ckBlast.IsCheckedChanged += ckBlast_CheckedChanged;
             nudBurstCount.ValueChanged += NudBurstCount_ValueChanged;
+            chkSortByChannel.Click += chkSortByChannelClicked;
         }
 
+        private void chkSortByChannelClicked(object? sender, RoutedEventArgs e)
+        {
+            // sort capture channels by channel number
+            if (chkSortByChannel.IsChecked == true) 
+                captureChannels = captureChannels.OrderBy(c => c.ChannelNumber).ToArray();
+            // sort capture channels by channel name
+            else
+            {
+                captureChannels = captureChannels.OrderBy(c => c.ChannelName == null ? 1:0)
+                                                 .ThenBy(c => Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
+                                                 .ThenBy(c => Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
+                                                 .ToArray();
+            }
+
+            // reinitialize rows of channel selectors
+            ReInitializeControlArrays();
+        }
         private void NudBurstCount_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
         {
             if (nudBurstCount.Value > 254)
@@ -281,6 +301,25 @@ namespace LogicAnalyzer.Dialogs
             return panel;
         }
 
+        private void ReInitializeControlArrays()
+        {
+            pnlChannels.Children.Clear();
+            int ChannelCount = captureChannels.Length;
+            List<ChannelSelector> channels = new List<ChannelSelector>();
+            for (int firstChan = 0; firstChan < ChannelCount; firstChan += 8)
+                pnlChannels.Children.Add(CreateChannelRow(firstChan, channels, ChannelCount));
+            for (int chan = 0; chan < channels.Count; chan++)
+            {
+                channels[chan].ChannelNumber = captureChannels[chan].ChannelNumber;
+                channels[chan].ChannelName = captureChannels[chan].ChannelName;
+                channels[chan].ChannelColor = captureChannels[chan].ChannelColor;
+                channels[chan].Enabled = captureChannels[chan].Enabled;
+            }
+            int maxTrigger = Math.Min(24, ChannelCount);
+            captureChannels = channels.ToArray();
+            triggerChannels = Enumerable.Range(0, maxTrigger).Select(i => this.FindControl<RadioButton>($"rbTrigger{i + 1}")).ToArray()!;
+        }
+
         private void InitializeControlArrays(int ChannelCount)
         {
             List<ChannelSelector> channels = new List<ChannelSelector>();
@@ -375,6 +414,17 @@ namespace LogicAnalyzer.Dialogs
                     captureChannels[channel.ChannelNumber].ChannelColor = channel.ChannelColor;
                 }
 
+                if (settings.SortOnNumber==false)
+                {
+                    captureChannels = captureChannels
+                        .OrderBy(c => c.ChannelName == null ? 1:0)
+                        .ThenBy(c => Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
+                        .ThenBy(c => Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
+                        .ToArray();
+                    ReInitializeControlArrays();
+                    chkSortByChannel.IsChecked = false;
+                }
+
                 if (settings.TriggerType == TriggerType.Blast)
                 {
                     SetBlastMode(true);
@@ -459,7 +509,7 @@ namespace LogicAnalyzer.Dialogs
             for (int buc = 0; buc < captureChannels.Length; buc++)
             {
                 if (captureChannels[buc].Enabled == true)
-                    channelsToCapture.Add(new AnalyzerChannel { ChannelName = captureChannels[buc].ChannelName, ChannelNumber = buc, ChannelColor = captureChannels[buc].ChannelColor });
+                    channelsToCapture.Add(new AnalyzerChannel { ChannelName = captureChannels[buc].ChannelName, ChannelNumber = captureChannels[buc].ChannelNumber, ChannelColor = captureChannels[buc].ChannelColor });
             }
 
             if (channelsToCapture.Count == 0)
@@ -594,6 +644,7 @@ namespace LogicAnalyzer.Dialogs
             settings.MeasureBursts = measure;
             settings.TriggerInverted = ckNegativeTrigger.IsChecked == true;
             settings.CaptureChannels = channelsToCapture.ToArray();
+            settings.SortOnNumber = chkSortByChannel.IsChecked == true;
             
             File.WriteAllText(settingsFile, JsonConvert.SerializeObject(settings));
             SelectedSettings = settings;

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/CaptureDialog.axaml.cs
@@ -71,8 +71,8 @@ namespace LogicAnalyzer.Dialogs
             else
             {
                 captureChannels = captureChannels.OrderBy(c => c.ChannelName == null ? 1:0)
-                                                 .ThenBy(c => Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
-                                                 .ThenBy(c => Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
+                                                 .ThenBy(c => c.ChannelName != null && Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
+                                                 .ThenBy(c => c.ChannelName != null && Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
                                                  .ToArray();
             }
 
@@ -418,8 +418,8 @@ namespace LogicAnalyzer.Dialogs
                 {
                     captureChannels = captureChannels
                         .OrderBy(c => c.ChannelName == null ? 1:0)
-                        .ThenBy(c => Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
-                        .ThenBy(c => Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
+                        .ThenBy(c => c.ChannelName != null && Regex.Match(c.ChannelName, @"\w").Success ? Regex.Match(c.ChannelName, @"\w").Value : "")
+                        .ThenBy(c => c.ChannelName != null && Regex.Match(c.ChannelName, @"\d+").Success ? Int16.Parse(Regex.Match(c.ChannelName, @"\d+").Value) : (short)99)
                         .ToArray();
                     ReInitializeControlArrays();
                     chkSortByChannel.IsChecked = false;

--- a/Software/LogicAnalyzer/SharedDriver/CaptureSession.cs
+++ b/Software/LogicAnalyzer/SharedDriver/CaptureSession.cs
@@ -28,6 +28,7 @@ namespace SharedDriver
         public bool TriggerInverted { get; set; }
         public int TriggerBitCount { get; set; }
         public ushort TriggerPattern { get; set; }
+        public bool SortOnNumber { get; set; }
 
         public CaptureSession Clone()
         {


### PR DESCRIPTION
Hi Dr. Guzman,

Thanks for your fantastic project! I added a sorting feature to 'intelligently' sort on ChannelName.

For example if you have your pins in random order connected and give them names like A2, A0, A1 and D3, D0, D2, D1 and /RW. You can sort them in the Capture overview and Main Screen as A0, A1, A2, D0, D1, D2, D3, /RW. 

Will also be retained as settings.

Check the screen shots:
<img width="1030" height="708" alt="sorted-by-channelnumber" src="https://github.com/user-attachments/assets/2b551ee7-e0dc-4131-bb49-73237425a010" /> -unsorted-

<img width="1030" height="707" alt="sorted-by-channelname" src="https://github.com/user-attachments/assets/186ae744-43c7-4b39-aec6-d5aff2520867" /> -sorted-

<img width="1920" height="1080" alt="fullscreen-sorted" src="https://github.com/user-attachments/assets/4ff6197c-0569-4a06-97c0-04de957c2052" /> -mainscreen- 

Regards,

Mario